### PR TITLE
Fix(ui): knoptekst aangepast naar 'Kleur bewaren'

### DIFF
--- a/Grocery.App/Views/ChangeColorView.xaml
+++ b/Grocery.App/Views/ChangeColorView.xaml
@@ -13,6 +13,6 @@
 
     <VerticalStackLayout>
         <Editor Text="{Binding GroceryList.Color}" x:Name="newColor"/>
-        <Button Text="wijzig kleur" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
+        <Button Text="Kleur bewaren" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
### UC04 Kiezen kleur boodschappenlijst
> De tekst van de knop om een kleur op te slaan is gewijzigd van 'Wijzig kleur' naar 'Kleur bewaren' .
<img width="385" height="854" alt="Scherm­afbeelding 2025-09-16 om 15 16 05" src="https://github.com/user-attachments/assets/3443ab75-8d00-49d4-a9f7-7b91819ef556" />
